### PR TITLE
Fix dev install commands, plus configuration extras

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,15 +11,12 @@ end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 
-[*.yaml]
+[*.{yaml,yml}]
 indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = true
 indent_size = 4
-
-[Makefile]
-indent_style = tab
 
 [LICENSE]
 insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# Documentation: https://EditorConfig.org
+# Inspired by Django .editorconfig file
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.yaml]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = true
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[LICENSE]
+insert_final_newline = false
+
+[*.{diff,patch}]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ mamba env create -f environment.yml
 As a developer:
 
 ```shell
-mamba create -n calliope-pathways -c conda-forge/label/calliope_dev -c conda-forge -f requirements/base.txt -f requirements/dev.txt
-mamba activate calliope-pathways
+mamba create -n calliope-pathways-dev -c conda-forge/label/calliope_dev -c conda-forge --file requirements/base.txt --file requirements/dev.txt
+mamba activate calliope-pathways-dev
 pip install --no-deps -e .
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ mamba env create -f environment.yml
 As a developer:
 
 ```shell
-mamba create -c conda-forge/label/calliope_dev -c conda-forge -f requirements/base.txt -f requirements/dev.txt
+mamba create -n calliope-pathways -c conda-forge/label/calliope_dev -c conda-forge -f requirements/base.txt -f requirements/dev.txt
+mamba activate calliope-pathways
 pip install --no-deps -e .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ filterwarnings = []
 
 [tool.black]
 line-length = 88
+skip-magic-trailing-comma = true
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ filterwarnings = []
 
 [tool.black]
 line-length = 88
-skip_magic_trailing_comma = true
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''


### PR DESCRIPTION
Three features:
- Removed a warning in pyproject.toml (trailing comma setting is invalid)
- Added .editorconfig to ensure .yaml tabs are 2, not 4.
- Workaround: altered the commands in README.md to avoid buggy `-f` behavior if multiple files are specified.