### PR TITLE
Add `py.typed`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ where = ["src"]
 include = ["calliope_pathways*"]
 
 [tool.setuptools.package-data]
-calliope_pathways = ["models/**/*", "math/*", "config/*"]
+calliope_pathways = ["models/**/*", "math/*", "config/*", "py.typed"]
 
 [tool.setuptools]
 license-files = ["LICENSE"]


### PR DESCRIPTION
So that calliope-pathways is recognised by mypy as having type hinting available when calliope-pathways is loaded as a dependency.