### PR TITLE
Add option to load user-defined model with pathways math

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# calliope-pathways
+# calliope-pathways - pathway optimisation in Calliope
 
 [![Documentation Status](https://readthedocs.org/projects/calliope-pathways/badge/?version=latest)](https://calliope-pathways.readthedocs.io/en/latest/?badge=latest)
 
-Pathway optimisation implementation built on top of Calliope v0.7
+Pathway optimisation implementation built on top of Calliope v0.7.
+
+The purpose of this repository is to store both the mathematical formulation and the toy models of pathway optimisation experiments.
+The main branch contains the most up-to-date version of the models and the math; branches include active experiments into methods to improve the math representation of pathway optimisation.
 
 ## Install
 
@@ -48,3 +51,44 @@ To install CBC into your mamba environment on MacOS / Linux:
 ```shell
 mamba install coin-or-cbc
 ```
+
+## Run a pre-defined model
+
+You can find examples of loading and running a pre-defined pathways optimisation model under "Examples and tutorial" in our documentation.
+
+## Build your own model
+
+To use pathway optimisation with your own model, use the `calliope.models.load(...)` function.
+This will add pathways math to your model math and parameter metadata to the calliope schema.
+Your pathways model will need to define:
+
+* The `investsteps` and `vintagesteps` dimensions.
+* Initial capacities of your technologies, setting the starting conditions of your model:
+    * `flow_cap_initial`
+    * `area_use_initial`
+    * `storage_cap_initial`
+    * `source_cap_initial`
+* The length of time your technologies are available after deployment (for new capacity) or from the first investment step (for initial capacity).
+This is given as fractions per investment step.
+Values between `0` and `1` allow you to represent technologies being phased out _between_ investment steps.
+    * `available_initial_cap`: this should be an array of fractions indexed over the `investsteps` dimension.
+    `1` means all initial capacity is still available in that investment step, `0` means that none of it is available.
+    * `available_vintages`: this should be an array of fractions indexed over the `investsteps` and `vintagesteps` dimensions.
+    `1` means all of a technology vintage's capacity is still available in that investment step, `0` means that none of it is available.
+    For instance, a "2030" technology vintage with a 20-year lifetime will be fully available in the "2030" and "2040" investment steps, but no longer available in "2050".
+    A "2030" technology vintage with a 15-year lifetime will be fully available in the "2030", but only 50% available in a "2040" investment step, then no longer available in "2050".
+* `investstep_resolution`: the weights of your investment steps, indexed over `investsteps`.
+This will likely be the number of years between your investment steps (e.g. a value of `10` for the steps [2030, 2040, 2050]).
+
+We expect to automate the generation of some of this data in future (e.g., capacity availability using technology lifetime, investment step resolution based on the `diff` of `investsteps`).
+In the meantime, we ask that you define the data explicitly in your model YAML / tabular data files.
+
+## Acknowledgements
+
+This repository structure and content is based heavily on the [`Calliope` repository](https://github.com/calliope-project/calliope).
+
+See the [callio.pe project website](https://www.callio.pe/partners-and-team/) for current and past team members and acknowledgements for Calliope.
+
+## License
+
+Copyright since 2024 Calliope pathways contributors listed in AUTHORS. Licensed under MIT.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,1 @@
-# Calliope pathways: Pathway optimisation in Calliope
-
-## Acknowledgements
-
-See the [callio.pe project website](https://www.callio.pe/partners-and-team/) for current and past team members and acknowledgements.
-
-## License
-
-Copyright since 2024 Calliope pathways contributors listed in AUTHORS. Licensed under MIT.
+--8<-- "README.md"

--- a/src/calliope_pathways/config/new_param_schema.yaml
+++ b/src/calliope_pathways/config/new_param_schema.yaml
@@ -55,3 +55,15 @@ techs:
     description: >-
       Sets `source_cap` lower bound in first investment period during pathway optimisation.
     x-unit: power.
+
+parameters:
+
+  investstep_resolution:
+    $ref: "#/$defs/TechParamNullNumber"
+    default: 1
+    x-type: float
+    title: Per-investment step weighting.
+    description: >-
+      The weighting to give to each investment-step in the objective function.
+      This usually refers to the number of years that one investment step represents (e.g. 10 years for the steps [2030, 2040, 2050]).
+    x-unit: years.

--- a/src/calliope_pathways/models.py
+++ b/src/calliope_pathways/models.py
@@ -8,25 +8,46 @@
 Models that can be loaded directly into a session.
 """
 
-import importlib
 from pathlib import Path
 
 from calliope import AttrDict
 from calliope.model import Model
 from calliope.util import schema
 
-MODEL_DIR = Path(importlib.resources.files("calliope_pathways") / "models")
-CONFIG_DIR = Path(importlib.resources.files("calliope_pathways") / "config")
+from calliope_pathways.util import src_dir_ref
 
-new_schema = AttrDict.from_yaml(CONFIG_DIR / "new_param_schema.yaml")
+new_schema = AttrDict.from_yaml(src_dir_ref("config") / "new_param_schema.yaml")
 
 for key, new_params in new_schema.items():
     schema.update_model_schema(key, new_params, allow_override=False)
 
 
-def national_scale(*args, **kwargs):
+def national_scale(**kwargs) -> Model:
     """Returns the built-in national-scale example model."""
 
     return Model(
-        model_definition=MODEL_DIR / "national_scale" / "model.yaml", *args, **kwargs
+        model_definition=src_dir_ref("models") / "national_scale" / "model.yaml",
+        **kwargs,
     )
+
+
+def load(
+    model_definition: str | Path, add_pathways_math: bool = True, **kwargs
+) -> Model:
+    """Load a user-defined model, adding calliope_pathways math if desired.
+
+    Args:
+        model_definition (str | Path): Path to user's `model.yaml` file.
+        add_pathways_math (bool, optional):
+            If True, the model math will be updated with pre-defined `calliope_pathways` math.
+            Set to False if you already have a reference to the math file in your `init.add_math` configuration.
+            Defaults to True.
+
+    Keyword Args: Passed on to `calliope.Model`.
+    """
+
+    model = Model(model_definition=model_definition, **kwargs)
+    if add_pathways_math:
+        math = AttrDict.from_yaml(src_dir_ref("math") / "pathways.yaml")
+        model.math.union(math, allow_override=True)
+    return model

--- a/src/calliope_pathways/util.py
+++ b/src/calliope_pathways/util.py
@@ -1,0 +1,9 @@
+import importlib.resources
+from pathlib import Path
+
+_SRC_DIR = importlib.resources.files("calliope_pathways")
+
+
+def src_dir_ref(dir: str | Path) -> Path:
+    with importlib.resources.as_file(_SRC_DIR) as f:
+        return f / dir

--- a/tests/test_user_defined_model.py
+++ b/tests/test_user_defined_model.py
@@ -1,0 +1,39 @@
+import calliope
+import pytest
+from calliope_pathways import models
+
+
+@pytest.fixture
+def load_example_model():
+    def _load_example_model(add_pathways_math):
+        model_path = (
+            calliope.examples._EXAMPLE_MODEL_DIR / "national_scale" / "model.yaml"
+        )
+        return models.load(model_path, add_pathways_math=add_pathways_math)
+
+    return _load_example_model
+
+
+@pytest.fixture
+def schema_defaults():
+    return calliope.util.schema.extract_from_schema(
+        calliope.util.schema.MODEL_SCHEMA, "default"
+    )
+
+
+def test_add_pathways_math(load_example_model):
+    model = load_example_model(True)
+    assert "flow_cap_bounding" in model.math.constraints.keys()
+    assert "flow_cap_new" in model.math.variables.keys()
+    assert "investsteps" in model.math.constraints["flow_out_max"]["foreach"]
+
+
+def test_load_no_pathways_math(load_example_model):
+    model = load_example_model(False)
+    assert "flow_cap_bounding" not in model.math.constraints.keys()
+    assert "flow_cap_new" not in model.math.variables.keys()
+    assert "investsteps" not in model.math.constraints["flow_out_max"]["foreach"]
+
+
+def test_parameters_in_schema(schema_defaults):
+    assert schema_defaults["flow_cap_initial"] == 0


### PR DESCRIPTION
In case a user wants to try out pathways with their own model.

I've also added a bit more information to the README on the parameters that are needed to build a pathways model.
To avoid duplication, the README now also acts as the documentation homepage.