### PR TITLE
Update install method & reorganise dependencies

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 conda:
-  environment: environment.yml
+  environment: requirements/base.txt
 build:
   os: ubuntu-22.04
   tools:
@@ -8,6 +8,7 @@ build:
   jobs:
     post_create_environment:
       - mamba install coin-or-cbc --file requirements/dev.txt
+      - pip install --no-deps .
       - python -m ipykernel install --user --name calliope_docs_pathways
 
 mkdocs:

--- a/README.md
+++ b/README.md
@@ -9,24 +9,17 @@ The main branch contains the most up-to-date version of the models and the math;
 
 ## Install
 
-You can install calliope pathways in one of two ways:
+You can install calliope pathways as a user or developer:
 
 As a user:
 
 ```shell
-mamba env create -f environment.yml
+mamba create -n calliope-pathways -c conda-forge/label/calliope_dev -c conda-forge --file requirements/base.txt
 mamba activate calliope-pathways
-```
-
-As a developer on WINDOWS:
-
-```shell
-mamba create -n calliope-pathways-dev -c conda-forge/label/calliope_dev -c conda-forge --file requirements/base.txt --file requirements/dev.txt
-mamba activate calliope-pathways-dev
 pip install --no-deps -e .
 ```
 
-As a developer on UNIX:
+As a developer:
 
 ```shell
 mamba create -n calliope-pathways-dev -c conda-forge/label/calliope_dev -c conda-forge --file requirements/base.txt --file requirements/dev.txt

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,0 @@
-name: calliope-pathways-test
-channels:
-  - conda-forge
-  - conda-forge/label/calliope_dev
-dependencies:
-  - calliope>=0.7.0dev3
-  - pip:
-    - "."

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-calliope>=0.7.0dev3
-numpy == 1.26
+calliope == 0.7.0dev3
+numpy >= 1.26
 plotly >= 5
 pyyaml >= 6
 pycountry == 22.3.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,7 @@
 calliope>=0.7.0dev3
+numpy == 1.26
+plotly >= 5
+pyyaml >= 6
+pycountry == 22.3.5
+pint-pandas >= 0.5
+powerplantmatching == 0.5.14

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,14 +5,8 @@ mkdocs-jupyter >= 0.24, < 0.24.7
 mkdocs-macros-plugin >= 1.0, < 2
 mkdocs-material >= 9.5, < 10
 mkdocstrings-python >= 1.7, < 2
-numpy
 pandas-stubs
-plotly >= 5, < 6
 pre-commit < 4
 pytest < 8
 pytest-order < 2
 pytest-xdist < 4
-pyyaml
-pycountry == 22.3.5
-pint-pandas
-powerplantmatching == 0.5.14


### PR DESCRIPTION
We were getting divergent dependencies due to having an `environment.yml` _and_ the requirements files. Plus lots of the user requirements were in `dev.txt` (i.e. only accessible to developers).

I've gone back to the more maintanable (albeit less intuitive to users) approach of installing via the `requirements/base.txt` file and added lower bounds to our dependencies.